### PR TITLE
Install All Modules implemented. target framework updated

### DIFF
--- a/ConsumerProjects/Installer.ConsumerWebApp/Installer.ConsumerWebApp.csproj
+++ b/ConsumerProjects/Installer.ConsumerWebApp/Installer.ConsumerWebApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/Installer.ConsumerWebApp.Infrastructure/Installer.ConsumerWebApp.Infrastructure.csproj
+++ b/Installer.ConsumerWebApp.Infrastructure/Installer.ConsumerWebApp.Infrastructure.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Installer.ConsumerWebAppSupperClean/Installer.ConsumerWebAppSupperClean.csproj
+++ b/Installer.ConsumerWebAppSupperClean/Installer.ConsumerWebAppSupperClean.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/Installer.Microsoft.ServiceCollection/Installer.Microsoft.ServiceCollection.csproj
+++ b/Installer.Microsoft.ServiceCollection/Installer.Microsoft.ServiceCollection.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>ServiceCollectionInstaller</PackageId>


### PR DESCRIPTION
because of Hierarchy order of project reference in dotnet I only scanned current Domain because if project A reference Project B and Project B reference Project C . we can scan assemblies from project C too. so most of the architecture patterns and practices will not have any problem by using this package. and I found small typo in the source code you can fix it if you like .
IStepableServiceCollectionInstaller => ISteppableServiceCollectionInstaller.
Target framework of the projects updated to dotnet 8